### PR TITLE
Make the table(s) more responsive

### DIFF
--- a/instaviz/__init__.py
+++ b/instaviz/__init__.py
@@ -17,5 +17,5 @@ def show(obj):
         instructions = get_instructions(obj.__code__)
         show_code_object(obj.__code__, instructions)
     else:
-        print("{0} is not compiled, could not located __code__ attribute.".format(type(obj)))
+        print("{0} is not compiled, could not locate __code__ attribute.".format(type(obj)))
         return

--- a/instaviz/templates/home.html
+++ b/instaviz/templates/home.html
@@ -110,7 +110,7 @@
     <h1>Code Object Visualizer</h1>
 
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-6 table-responsive">
             <h2>Code Object Properties</h2>
             <table class="table table-sm">
                 <thead>
@@ -137,7 +137,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-6 table-responsive">
             <h2>Disassembled Code</h2>
             <table class="table table-sm">
                 <thead>


### PR DESCRIPTION
Minor change to use bootstrap's responsive table (or div, in this case) design, since currently whenever one of the code properties returned in the table is a bit long, it goes on top of the other table as you can see in the "before" (attached) screenshot which makes everything hard to see - also attached the "After" screenshot - tested in Chrome as well as FF.

Before:

![before](https://user-images.githubusercontent.com/12733941/56063099-09e4ed00-5d77-11e9-9c96-dda908a52cfa.png)

After:

![after](https://user-images.githubusercontent.com/12733941/56063098-09e4ed00-5d77-11e9-8ea3-a8c28e448855.png)

Thanks.