### PR TITLE
Added pyreadline dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
     ],
     packages=["instaviz"],
     include_package_data=True,
-    install_requires=["bottle", "jinja2", "pygments", "dill"]
+    install_requires=["bottle", "jinja2", "pygments", "dill", "pyreadline"]
 )


### PR DESCRIPTION
On a standard windows 10 installation running instaviz fails with a modulenotfound error. The output suggests installing pyreadline. The [Dill package page](https://pypi.org/project/dill/) shows that pyreadline is an optional requirement

Tested on both Windows and CentOS 7

Fixes #10