### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Instant visualization of Python AST and Code Objects.
 
 ## Installation
 
-Requires modern Python 3.6+
+Requires modern Python 3.7+
 
 ```bash
 pip install instaviz

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=["instaviz"],
     include_package_data=True,


### PR DESCRIPTION
The README.md stated, you can use Python 3.6+, which I understand as 3.6
and above.

However, the source code uses f-strings, which are 3.7 and above only.

README.md has been updated.

Also, added classifier for Python 3.8.

modified:   setup.py